### PR TITLE
Preserve content formatting in SingleNews and SingleEvent components

### DIFF
--- a/src/pages/detail/SingleEvent.js
+++ b/src/pages/detail/SingleEvent.js
@@ -118,7 +118,14 @@ const SingleEvent = () => {
       </div>
 
       <h5 className="event-organizer">Organized by: {eventItem.organizer} on <br />{new Date(eventItem.event_date).toLocaleDateString()} at {eventItem.event_time}</h5>
-      <p className="single-event-content">{eventItem.content}</p>
+      <p className="single-event-content">
+        {eventItem.content.split('\n').map((line, index) => (
+          <React.Fragment key={index}>
+            {line}
+            <br />
+          </React.Fragment>
+        ))}
+      </p>
     </div>
   );
 };

--- a/src/pages/detail/SingleNews.js
+++ b/src/pages/detail/SingleNews.js
@@ -115,7 +115,14 @@ const SingleNews = () => {
         )}
       </div>
 
-      <p className="single-news-content">{newsItem.content}</p>
+      <p className="single-news-content">
+        {newsItem.content.split('\n').map((line, index) => (
+          <React.Fragment key={index}>
+            {line}
+            <br />
+          </React.Fragment>
+        ))}
+      </p>
     </div>
   );
 };

--- a/src/pages/pages.css
+++ b/src/pages/pages.css
@@ -1067,6 +1067,7 @@ button:hover {
   line-height: 1.8;
   color: #333333;
   width: 60%;
+  white-space: pre-wrap;
 }
 
 .single-news-content img {
@@ -1112,6 +1113,7 @@ button:hover {
   line-height: 1.8;
   color: #333333;
   width: 60%;
+  white-space: pre-wrap;
 }
 
 .event-organizer {


### PR DESCRIPTION
- Updated SingleNews and SingleEvent components to maintain line breaks in content fields.
- Added split and map logic to render each line with <br> tags.
- Applied CSS white-space: pre-wrap to ensure whitespace is preserved in content display.